### PR TITLE
enable retrieval of GTIDs via Conn and Transaction

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -387,6 +387,8 @@ pub(crate) struct MysqlOpts {
     ///
     /// Note that compression level defined here will affect only outgoing packets.
     compression: Option<crate::Compression>,
+
+    capabilities: CapabilityFlags
 }
 
 /// Mysql connection options.
@@ -658,17 +660,7 @@ impl Opts {
     }
 
     pub(crate) fn get_capabilities(&self) -> CapabilityFlags {
-        let mut out = CapabilityFlags::CLIENT_PROTOCOL_41
-            | CapabilityFlags::CLIENT_SECURE_CONNECTION
-            | CapabilityFlags::CLIENT_LONG_PASSWORD
-            | CapabilityFlags::CLIENT_TRANSACTIONS
-            | CapabilityFlags::CLIENT_LOCAL_FILES
-            | CapabilityFlags::CLIENT_MULTI_STATEMENTS
-            | CapabilityFlags::CLIENT_MULTI_RESULTS
-            | CapabilityFlags::CLIENT_PS_MULTI_RESULTS
-            | CapabilityFlags::CLIENT_DEPRECATE_EOF
-            | CapabilityFlags::CLIENT_PLUGIN_AUTH;
-
+        let mut out = self.inner.mysql_opts.capabilities;
         if self.inner.mysql_opts.db_name.is_some() {
             out |= CapabilityFlags::CLIENT_CONNECT_WITH_DB;
         }
@@ -684,7 +676,19 @@ impl Opts {
 }
 
 impl Default for MysqlOpts {
+    
     fn default() -> MysqlOpts {
+        let default_caps = CapabilityFlags::CLIENT_PROTOCOL_41
+        | CapabilityFlags::CLIENT_SECURE_CONNECTION
+        | CapabilityFlags::CLIENT_LONG_PASSWORD
+        | CapabilityFlags::CLIENT_TRANSACTIONS
+        | CapabilityFlags::CLIENT_LOCAL_FILES
+        | CapabilityFlags::CLIENT_MULTI_STATEMENTS
+        | CapabilityFlags::CLIENT_MULTI_RESULTS
+        | CapabilityFlags::CLIENT_PS_MULTI_RESULTS
+        | CapabilityFlags::CLIENT_DEPRECATE_EOF
+        | CapabilityFlags::CLIENT_PLUGIN_AUTH;
+
         MysqlOpts {
             user: None,
             pass: None,
@@ -700,6 +704,7 @@ impl Default for MysqlOpts {
             prefer_socket: true,
             socket: None,
             compression: None,
+            capabilities:  default_caps
         }
     }
 }
@@ -906,6 +911,18 @@ impl OptsBuilder {
     /// Defines compression. See [`Opts::compression`].
     pub fn compression<T: Into<Option<crate::Compression>>>(mut self, compression: T) -> Self {
         self.opts.compression = compression.into();
+        self
+    }
+
+    /// Adds capability flag. See [`Opts::capabilities`].
+    pub fn add_capability(mut self, cap_flag: CapabilityFlags) -> Self {
+        self.opts.capabilities |= cap_flag;
+        self
+    }
+
+    /// Removes capability flag. See [`Opts::capabilities`].
+    pub fn remove_capability(mut self, cap_flag: CapabilityFlags) -> Self {
+        self.opts.capabilities &= !cap_flag;
         self
     }
 }

--- a/src/queryable/transaction.rs
+++ b/src/queryable/transaction.rs
@@ -189,6 +189,15 @@ impl<'a> Transaction<'a> {
         self.0.set_tx_status(TxStatus::None);
         Ok(())
     }
+
+    /// Performs `COMMIT` query and returns GTID.
+    pub async fn commit_returning_gtid(mut self) -> Result<String> {
+        let result = self.0.query_iter("COMMIT").await?;
+        result.drop_result().await?;
+        self.0.set_tx_status(TxStatus::None);
+        let gtid = self.0.session_state_changes_track_gtids();
+        gtid.ok_or(Error::Other("GTID not found".into()))
+    }
 }
 
 impl Deref for Transaction<'_> {


### PR DESCRIPTION
## Overview
Giving the user access to GTIDs from OK packets acking commits involves
two main changes.

1) enabling configuration of capability flags for Opts
so that CLIENT_SESSION_TRACK can be enabled. 

2) adding a new public
method to Conn to retrieve the session state change information.

## Known Issues
I played around awhile with the changes in mod.rs, but let me know if there is a more idiomatic way to do what I'm doing.
The testing assumes that the database is configured properly, but I didn't actually make changes to the azure pipeline stuff since that seemed like not a great immediate use of my time.

## Testing
New unit test passes with properly configured database.
Also tested manually with our client and it works!