### PR TITLE
enable retrieval of GTIDs from OK packets via Conn and Transaction

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -188,6 +188,27 @@ impl Conn {
             .unwrap_or_else(|| "".into())
     }
 
+    /// Session state change for SESSION_TRACK_GTIDS type as reported by the server
+    /// in the last OK packet
+    /// If called immediately after commit, should contain the GTID of the committed transaction.
+    pub fn session_state_changes_track_gtids(&self) -> Option<String> {
+        self.inner
+            .last_ok_packet
+            .as_ref()
+            .and_then(|ok| ok.session_state_info())
+            .and_then(|info| match info.data_type() {
+                mysql_common::constants::SessionStateType::SESSION_TRACK_GTIDS => info
+                    .decode()
+                    .map_or(None, |state_change| match state_change {
+                        mysql_common::packets::SessionStateChange::UnknownLayout(data) => {
+                            Some(String::from_utf8_lossy(data.as_ref()).to_string())
+                        }
+                        _ => None,
+                    }),
+                _ => None,
+            })
+    }
+
     /// Number of warnings, as reported by the server in the last OK packet, or `0`.
     pub fn get_warnings(&self) -> u16 {
         self.inner
@@ -803,6 +824,8 @@ impl Conn {
 
 #[cfg(test)]
 mod test {
+    use mysql_common::constants::CapabilityFlags;
+
     use crate::{
         from_row, params, prelude::*, test_misc::get_opts, Conn, Error, OptsBuilder, Pool, TxOpts,
         WhiteListFsLocalInfileHandler,
@@ -1402,6 +1425,38 @@ mod test {
         Ok(())
     }
 
+    // TODO(andrewtsakiris): In order to push these changes upstream, need to configure test DB
+    // to have proper GTID-enabled configuration. This test assumes relevant system variables are
+    // set properly on the server.
+    #[tokio::test]
+    async fn should_get_gtid_after_transaction() -> super::Result<()> {
+        let mut conn =
+            Conn::new(get_opts().add_capability(CapabilityFlags::CLIENT_SESSION_TRACK)).await?;
+
+        // Using Conn
+        conn.query_drop("DROP TABLE IF EXISTS gtid_test").await?;
+        conn.query_drop("CREATE TABLE gtid_test (id INT, name TEXT)")
+            .await?;
+        conn.query_drop("START TRANSACTION").await?;
+        conn.query_drop("INSERT INTO gtid_test VALUES (1, 'foo'), (2, 'bar')")
+            .await?;
+        conn.query_drop("COMMIT").await?;
+        let gtid = conn.session_state_changes_track_gtids();
+        assert!(gtid.is_some() && gtid.unwrap().contains(":")); // expecting "<server>:<txid>"
+
+        // Using Transaction
+        let mut transaction = conn.start_transaction(TxOpts::default()).await?;
+        transaction
+            .query_drop("INSERT INTO gtid_test VALUES (1, 'foo'), (2, 'bar')")
+            .await?;
+        let gtid = transaction.commit_returning_gtid().await?;
+        assert!(gtid.len() > 0 && gtid.contains(":"));
+
+        conn.query_drop("DROP TABLE gtid_test").await?;
+        conn.disconnect().await?;
+
+        Ok(())
+    }
     #[tokio::test]
     async fn should_run_transactions() -> super::Result<()> {
         let mut conn = Conn::new(get_opts()).await?;

--- a/src/queryable/transaction.rs
+++ b/src/queryable/transaction.rs
@@ -189,6 +189,15 @@ impl<'a> Transaction<'a> {
         self.0.set_tx_status(TxStatus::None);
         Ok(())
     }
+
+    /// Performs `COMMIT` query and returns GTID.
+    pub async fn commit_returning_gtid(mut self) -> Result<String> {
+        let result = self.0.query_iter("COMMIT").await?;
+        result.drop_result().await?;
+        self.0.set_tx_status(TxStatus::None);
+        let gtid = self.0.session_state_changes_track_gtids();
+        gtid.ok_or(Error::Other("GTID not found".into()))
+    }
 }
 
 impl Deref for Transaction<'_> {


### PR DESCRIPTION
## Overview
Giving the user access to GTIDs from OK packets acking commits involves
two main changes.

1) enabling configuration of capability flags for Opts
so that CLIENT_SESSION_TRACK can be enabled. 

2) adding a new public
method to Conn to retrieve the session state change information.

## Known Issues
I played around awhile with the changes in mod.rs, but let me know if there is a more idiomatic way to do what I'm doing.
The testing assumes that the database is configured properly, but I didn't actually make changes to the azure pipeline stuff since that seemed like not a great immediate use of my time.

## Testing
New unit test passes with properly configured database.
Also tested manually with our client and it works!