### PR TITLE
Use a lockfree structure for BufferPool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["asynchronous", "database"]
 
 [dependencies]
 bytes = "1.0"
+crossbeam = "0.8"
 flate2 = { version = "1.0", default-features = false }
 futures-core = "0.3"
 futures-util = "0.3"


### PR DESCRIPTION
Currently the Mutex in BufferPool may be contested
under heavy load, which increases the load even
more, leading to a steep drop in QPS. Using a lockfree
ArrayQueue instead resolves the issue improving
performance by up to 4x.