### PR TITLE
Usability improvement: leading forward slash empty database

### DIFF
--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -1356,11 +1356,14 @@ fn get_opts_pass_from_url(url: &Url) -> Option<String> {
 
 fn get_opts_db_name_from_url(url: &Url) -> Option<String> {
     if let Some(mut segments) = url.path_segments() {
-        segments.next().map(|db_name| {
-            percent_decode(db_name.as_ref())
-                .decode_utf8_lossy()
-                .into_owned()
-        })
+        segments
+            .next()
+            .map(|db_name| {
+                percent_decode(db_name.as_ref())
+                    .decode_utf8_lossy()
+                    .into_owned()
+            })
+            .filter(|db| !db.is_empty())
     } else {
         None
     }
@@ -1828,5 +1831,19 @@ mod test {
 
         let opts = Opts::from_url("mysql://localhost/foo?compression=9").unwrap();
         assert_eq!(opts.compression(), Some(crate::Compression::new(9)));
+    }
+
+    #[test]
+    fn test_builder_eq_url_empty_db() {
+        let builder = super::OptsBuilder::default();
+        let builder_opts = Opts::from(builder);
+
+        let url: &str = "mysql://iq-controller@localhost";
+        let url_opts = super::Opts::from_str(url).unwrap();
+        assert_eq!(url_opts.db_name(), builder_opts.db_name());
+
+        let url: &str = "mysql://iq-controller@localhost/";
+        let url_opts = super::Opts::from_str(url).unwrap();
+        assert_eq!(url_opts.db_name(), builder_opts.db_name());
     }
 }


### PR DESCRIPTION
A leading forward slash in the connection URL makes get_opts_db_name_from_url set db_name to Some("") rather than None. This makes code pulling the db from config requiring extra checks as db_name.is_some() will evaluate to true.
Empty database parameter is invalid for MySQL.

This causes all tables not to be replicated in the case of --upstream-db-url ending with a forward slash.

(cherry picked from upstream commit 2a716a6521428d62ab3e25dfae54a72257428f42)