### PR TITLE
Update mysql_common to v0.36.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
 lru = "0.16.3"
-mysql_common = { version = "0.35.4", default-features = false }
+mysql_common = { version = "0.36.2", default-features = false }
 pem = "3.0"
 percent-encoding = "2.1.0"
 rand = "0.9"

--- a/src/conn/routines/exec.rs
+++ b/src/conn/routines/exec.rs
@@ -83,7 +83,8 @@ impl Routine<()> for ExecRoutine<'_> {
                         }
 
                         let named = mem::replace(&mut self.params, Params::Empty);
-                        self.params = named.into_positional(&self.stmt.named_params)?;
+                        self.params =
+                            Params::Positional(named.into_values(Some(&self.stmt.named_params))?);
 
                         continue;
                     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,8 +11,11 @@ pub use url::ParseError;
 pub mod tls;
 
 use mysql_common::{
-    named_params::MixedParamsError, params::MissingNamedParameterError,
-    proto::codec::error::PacketCodecError, row::Row, value::Value,
+    named_params::MixedParamsError,
+    params::{MissingNamedParameterError, ParamsError},
+    proto::codec::error::PacketCodecError,
+    row::Row,
+    value::Value,
 };
 use thiserror::Error;
 
@@ -296,6 +299,15 @@ impl From<MixedParamsError> for DriverError {
 impl From<MixedParamsError> for Error {
     fn from(err: MixedParamsError) -> Self {
         Error::Driver(err.into())
+    }
+}
+
+impl From<ParamsError> for Error {
+    fn from(err: ParamsError) -> Self {
+        match err {
+            ParamsError::Missing(e) => e.into(),
+            ParamsError::Confusion(_) => Error::Driver(DriverError::NamedParamsForPositionalQuery),
+        }
     }
 }
 


### PR DESCRIPTION
Replace deprecated `into_positional` with `into_values` and add `From<ParamsError>` impl for the new error type.